### PR TITLE
예외 추가: 시간축 되돌아갔을 때 발생시킬 `ClockBackwardException` 클래스

### DIFF
--- a/src/main/java/me/letsdev/time/exception/ClockBackwardException.java
+++ b/src/main/java/me/letsdev/time/exception/ClockBackwardException.java
@@ -1,0 +1,41 @@
+package me.letsdev.time.exception;
+
+import java.time.Instant;
+
+import static java.time.temporal.ChronoField.MILLI_OF_SECOND;
+
+public class ClockBackwardException extends RuntimeException {
+
+    private final Instant currentTimestamp;
+    private final Instant lastTimestamp;
+
+    public ClockBackwardException(long timestamp, long lastTimestamp) {
+        this(Instant.ofEpochMilli(timestamp), Instant.ofEpochMilli(lastTimestamp));
+    }
+
+    public ClockBackwardException(Instant currentTimestamp, Instant lastTimestamp) {
+        super(
+                """
+                Clock moved backwards. Refusing to generate id for %d milliseconds.
+                 Current Timestamp: %d (%s)
+                 Last timestamp: %d (%s)""".formatted(
+                        lastTimestamp.getLong(MILLI_OF_SECOND),
+                        currentTimestamp.toEpochMilli(),
+                        currentTimestamp,
+                        lastTimestamp.toEpochMilli(),
+                        lastTimestamp
+                )
+        );
+
+        this.currentTimestamp = currentTimestamp;
+        this.lastTimestamp = lastTimestamp;
+    }
+
+    public Instant getCurrentInstant() {
+        return currentTimestamp;
+    }
+
+    public Instant getLastInstant() {
+        return lastTimestamp;
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issues

<!-- 이 PR이 완전히 처리한 이슈의 번호를 작성합니다. PR 병합 시 이슈가 자동으로 close 됩니다. -->
<!-- 다른 레포지터리의 이슈: `Resolves nettee-space/another-repository#0` -->

- Resolves #3 

## Description

- 시간축이 되돌아갔을 때 발생시킬 예외 `ClockBackwardException` 클래스를 추가합니다.

## How Has This Been Tested?

- 테스트하지 않습니다.
